### PR TITLE
Whitelist hosts

### DIFF
--- a/Classes/KFProxy.php
+++ b/Classes/KFProxy.php
@@ -7,6 +7,7 @@ class KFProxy
     private $headers;
     private $host;
     
+    private static $hostWhitelist = ["https://services.kortforsyningen.dk/"];
 
     public function __construct($url = null)
     {
@@ -45,6 +46,10 @@ class KFProxy
 
     public function getData() 
     {
+        if (!$this->urlHostIsWhitelisted()) {
+            throw new Error("URL not whitelisted");
+        }
+
         $curl = curl_init();
         curl_setopt_array($curl, [
             CURLOPT_URL => $this->url,
@@ -59,6 +64,10 @@ class KFProxy
     
     public function postData($params) 
     {
+        if (!$this->urlHostIsWhitelisted()) {
+            throw new Error("URL not whitelisted");
+        }
+
         //$fp = fopen(dirname(__FILE__).'/errorlog.txt', 'w');
         $curl = curl_init();
         curl_setopt_array($curl, [
@@ -74,5 +83,16 @@ class KFProxy
         $data = json_decode(curl_exec($curl), true);
         curl_close($curl);
         return $data;
+    }
+
+    public function urlHostIsWhitelisted()
+    {
+        foreach (KFProxy::$hostWhitelist as $host) {
+            if (substr($this->url, 0, strlen($host)) === $host) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/tests/KFProxyTests.php
+++ b/tests/KFProxyTests.php
@@ -1,0 +1,18 @@
+<?php
+    include_once __DIR__.'/../Classes/KFProxy.php';
+
+    $proxy = new KFProxy("");
+
+    assert(!$proxy->urlHostIsWhitelisted(), "Empty url should not validate");
+
+    $proxy->setUrl("https://services.kortforsyningen.dk/rest/arkivkort/iiif/2/Lzk2IC0gdG9wb2dyYWZpc2tlIGtvcnQsIGVrc3Rlcm5lLzk2LTIxIFRyYXAvNTA4L3RyXzIwMDY2NTEuanBn");
+    assert($proxy->urlHostIsWhitelisted(), "Realworld example should validate");
+
+    $proxy->setUrl("http://services.kortforsyningen.dk/rest/arkivkort/iiif/2/Lzk2IC0gdG9wb2dyYWZpc2tlIGtvcnQsIGVrc3Rlcm5lLzk2LTIxIFRyYXAvNTA4L3RyXzIwMDY2NTEuanBn");
+    assert(!$proxy->urlHostIsWhitelisted(), "Non https should not validate");
+
+    $proxy->setUrl("https://evilhost.example.com/");
+    assert(!$proxy->urlHostIsWhitelisted(), "Other hosts should not validate");
+
+    $proxy->setUrl("https://services.kortforsyningen.dk.evilhost.example.com/");
+    assert(!$proxy->urlHostIsWhitelisted(), "Other hosts containing valid subdomain should not validate");

--- a/tests/test_php.ini
+++ b/tests/test_php.ini
@@ -1,0 +1,1 @@
+zend.assertions 1


### PR DESCRIPTION
Check KFProxy urls agains whitelist to avoid leaking Kortforsyningen token.

If a malicious user makes a request to `/arkivkort/viewImage.php` with `imageUrl` set to `http://evil-host.com`, KFProxy may send a request too evil-host.com, where they can read the token value.

Tests can be run with `php -c ./tests/ tests/KFProxyTests.php` - no output is good.